### PR TITLE
fix antibody pars for >2 doses.

### DIFF
--- a/R/parameters_vaccine.R
+++ b/R/parameters_vaccine.R
@@ -40,13 +40,9 @@ get_vaccine_ab_titre_parameters <- function(
   stopifnot(all(is.finite(c(hl_s, hl_l, period_s, t_period_l, ab_50, ab_50_severe, std10, k))))
   stopifnot(all(c(hl_s, hl_l, period_s, t_period_l, ab_50, ab_50_severe, std10, k) > 0))
 
-
   time_to_decay <- t_period_l - period_s # time in days to reach longest half-life
   dr_s <- -log(2)/hl_s # Corresponding decay rate in days for half life above
   dr_l <- -log(2)/hl_l
-
-  mu_ab_d1 <- mu_ab_list[mu_ab_list$name == vaccine, "mu_ab_d1"] # mean titre dose 1
-  mu_ab_d2 <- mu_ab_list[mu_ab_list$name == vaccine, "mu_ab_d2"] # mean titre dose 2
 
   dr_vec <- c(
     rep(dr_s, period_s),
@@ -54,11 +50,10 @@ get_vaccine_ab_titre_parameters <- function(
     dr_l
   )
 
-  if (max_dose == 3) {
-    mu_ab = rep(c(mu_ab_d1, mu_ab_d2), times = c(1,2))
-  } else {
-    mu_ab = rep(c(mu_ab_d1, mu_ab_d2), times = c(1,1))
-  }
+  mu_ab <- as.numeric(mu_ab_list[mu_ab_list$name == vaccine, -1])
+
+  stopifnot(length(mu_ab) >= max_dose)
+  stopifnot(all(is.finite(mu_ab)))
 
   parameters <- list(
     dr_vec = dr_vec,

--- a/inst/test_scripts/sim_vaccine_3dose_notypes_model.R
+++ b/inst/test_scripts/sim_vaccine_3dose_notypes_model.R
@@ -40,7 +40,14 @@ parameters <- safir::get_parameters(
 )
 
 # vaccine parameters
-ab_parameters <- get_vaccine_ab_titre_parameters(vaccine = "Pfizer", max_dose = vaccine_doses,correlated = TRUE)
+mu_ab_list_3dose <- data.frame(
+  name = c("Pfizer", "AstraZeneca", "Sinovac", "Moderna"),
+  d1 = c(13/94, 1/59, 28/164, ((185 + 273)/2)/321),
+  d2 = c(223/94, 32/59,28/164, 654/158)
+)
+mu_ab_list_3dose <- cbind(mu_ab_list_3dose, d3 = mu_ab_list_3dose[, 3])
+
+ab_parameters <- get_vaccine_ab_titre_parameters(vaccine = "Pfizer", max_dose = vaccine_doses,correlated = TRUE,mu_ab_list = mu_ab_list_3dose)
 
 # combine parameters and verify
 parameters <- make_vaccine_parameters(


### PR DESCRIPTION
fix get_vaccine_ab_titre_parameters to properly specify antibody boosting from >2 doses. Affects R/parameters_vaccine.R and inst/test_scripts/sim_vaccine_3dose_notypes_model.R